### PR TITLE
fix: example shaders (#31)

### DIFF
--- a/example/expandedlife.glsl
+++ b/example/expandedlife.glsl
@@ -15,6 +15,7 @@ float random (in vec2 point) {
 	return fract(100.0 * sin(point.x + fract(100.0 * sin(point.y)))); // http://www.matteo-basei.it/noise
 }
 
+layout(location = 0) out vec4 diffuseColor;
 void main() {
 	vec2 p = gl_FragCoord.xy;
 	int n = 0;
@@ -42,5 +43,5 @@ void main() {
 		color = vec4(random(p) < 0.5 ? 1 : 0);
 	}
 
-	gl_FragColor = color;
+	diffuseColor = color;
 }

--- a/example/filter.glsl
+++ b/example/filter.glsl
@@ -10,6 +10,7 @@ uniform vec2 mouse;
 uniform sampler2D prevBuffer;
 uniform sampler2D currentBuffer;
 
+layout(location = 0) out vec4 diffuseColor;
 void main() {
 	vec2 p = gl_FragCoord.xy;
 
@@ -32,5 +33,5 @@ void main() {
 	  }
 	}
 
-	gl_FragColor = vec4(vec3(colors[4]), 1.0);
+	diffuseColor = vec4(vec3(colors[4]), 1.0);
 }

--- a/example/frag0.glsl
+++ b/example/frag0.glsl
@@ -1,3 +1,5 @@
+#version 330 core
+
 uniform vec2 resolution;
 uniform float time;
 uniform vec2 mouse;
@@ -63,6 +65,7 @@ vec3 palette(in float t) {
   return a + b * cos(6.28318 * (c * t + d));
 }
 
+layout(location = 0) out vec4 diffuseColor;
 void main() {
   vec2 p = gl_FragCoord.xy / resolution.xy;
   p.x *= resolution.x / resolution.y;
@@ -70,5 +73,5 @@ void main() {
   float value = pow(pattern(p), 2.);
   vec3 color  = palette(value);
 
-  gl_FragColor = vec4(color, 1.);
+  diffuseColor = vec4(color, 1.);
 }

--- a/example/frag1.glsl
+++ b/example/frag1.glsl
@@ -1,3 +1,5 @@
+#version 330 core
+
 #ifdef GL_ES
 precision highp float;
 #endif
@@ -49,7 +51,7 @@ float field(in vec3 p) {
 }
 
 
-
+layout(location = 0) out vec4 diffuseColor;
 void main() {   
      	vec2 uv2 = 2. * gl_FragCoord.xy / vec2(512) - 1.;
 	vec2 uvs = uv2 * vec2(512)  / 512.;
@@ -166,7 +168,7 @@ void main() {
 	backCol2.b = 0.5*mix(backCol2.g, backCol2.b, 0.8);
 	backCol2.g = 0.0;
 	backCol2.bg = mix(backCol2.gb, backCol2.bg, 0.5*(cos(time*0.01) + 1.0));	
-	gl_FragColor = forCol2 + vec4(backCol2, 1.0);
+	diffuseColor = forCol2 + vec4(backCol2, 1.0);
 }
 
 

--- a/example/frag2.glsl
+++ b/example/frag2.glsl
@@ -1,7 +1,7 @@
 /*
  * Original shader from: https://www.shadertoy.com/view/Wscyz2
  */
-
+#version 330 core
 
 #ifdef GL_ES
 precision highp float;
@@ -122,7 +122,8 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
 }
 // --------[ Original ShaderToy ends here ]---------- //
 
+layout(location = 0) out vec4 diffuseColor;
 void main(void)
 {
-    mainImage(gl_FragColor, gl_FragCoord.xy);
+    mainImage(diffuseColor, gl_FragCoord.xy);
 }

--- a/example/gameoflife.glsl
+++ b/example/gameoflife.glsl
@@ -13,6 +13,8 @@ float random (in vec2 point) {
 	return fract(100.0 * sin(point.x + fract(100.0 * sin(point.y)))); // http://www.matteo-basei.it/noise
 }
 
+layout(location = 0) out vec4 diffuseColor;
+
 void main() {
 	vec2 p = gl_FragCoord.xy;
 
@@ -39,5 +41,5 @@ void main() {
 		color = random(p) > 0.5 ? vec3(1) : vec3(0);
 	}
 
-	gl_FragColor = vec4(color, 1.);
+	diffuseColor = vec4(color, 1.);
 }

--- a/example/mouse.glsl
+++ b/example/mouse.glsl
@@ -1,3 +1,5 @@
+#version 330 core
+
 #ifdef GL_ES
 precision highp float;
 #endif
@@ -31,6 +33,7 @@ vec2 limit(vec2 v) {
 	return v/sqrt(v.x*v.x+v.y*v.y+9.0);
 }
 
+layout(location = 0) out vec4 diffuseColor;
 void main( void ) {
 	
 	float scaling_factor = resolution.x / resolution.y;
@@ -51,6 +54,6 @@ void main( void ) {
 	color +=  0.1 / abs(ellipse(0.5, Mouse, Right*limit(Mouse)*0.25, Screen));
 	color += 01.01 / abs(lines(0.5, Mouse, Screen)) * btw(add(Mouse*Screen), (-0.01*add(Mouse*Mouse)), (add(Mouse*Mouse)));
 
-	gl_FragColor = vec4( vec3( color*1.0, color*0.2, color*0.7 ), color / 2.0 );
+	diffuseColor = vec4( vec3( color*1.0, color*0.2, color*0.7 ), color / 2.0 );
 
 }

--- a/example/te2.glsl
+++ b/example/te2.glsl
@@ -1,3 +1,5 @@
+#version 330 core
+
 #ifdef GL_ES
 precision highp float;
 #endif
@@ -254,6 +256,7 @@ vec3 Text(vec2 uv)
     	return col;
 }
 
+layout(location = 0) out vec4 diffuseColor;
 void main( void )
 {
 	vec2 uv = gl_FragCoord.xy / DOWN_SCALE;
@@ -264,5 +267,5 @@ void main( void )
 	vec3 col = pixel*0.9+0.1;
 	col *= (1.-distance(mod(uv,vec2(1.0)),vec2(0.65)))*1.2;
 	
-	gl_FragColor = vec4(vec3(col), pow(col.r + col.g + col.b, 2.0));
+	diffuseColor = vec4(vec3(col), pow(col.r + col.g + col.b, 2.0));
 }

--- a/example/test.glsl
+++ b/example/test.glsl
@@ -1,3 +1,5 @@
+#version 330 core
+
 #ifdef GL_ES
 precision highp float;
 #endif
@@ -50,6 +52,7 @@ float field(in vec3 p) {
 
 
 
+layout(location = 0) out vec4 diffuseColor;
 void main() {   
      	vec2 uv2 = 2. * gl_FragCoord.xy / vec2(512) - 1.;
 	vec2 uvs = uv2 * vec2(512)  / 512.;
@@ -166,7 +169,7 @@ void main() {
 	backCol2.b = 0.5*mix(backCol2.g, backCol2.b, 0.8);
 	backCol2.g = 0.0;
 	backCol2.bg = mix(backCol2.gb, backCol2.bg, 0.5*(cos(time*0.01) + 1.0));	
-	gl_FragColor = forCol2 * vec4(vec3(1), pow(forCol2.r * forCol2.g * forCol2.b, 0.6));
+	diffuseColor = forCol2 * vec4(vec3(1), pow(forCol2.r * forCol2.g * forCol2.b, 0.6));
 }
 
 


### PR DESCRIPTION
Went through the minor chore of fixing all shader scripts so they are correctly loaded again (see #31). Maybe the naming convention `diffuseColor` can be improved?