### PR TITLE
fix: crash when surface is resized (probably fixes #29)

### DIFF
--- a/shadow/components.py
+++ b/shadow/components.py
@@ -180,8 +180,7 @@ class ComponentAnimatedImage():
 
 
     def cleanup(self):
-        for texID in self.textures:
-            gl.glDeleteTextures(1, texID)
+        gl.glDeleteTextures(len(self.textures), self.textures)
 
         del self.shader
 
@@ -264,7 +263,7 @@ class ComponentImage():
 
 
     def cleanup(self):
-        gl.glDeleteTextures(1, self.texture_id)
+        gl.glDeleteTextures(1, [self.texture_id])
         del self.shader
 
     @staticmethod
@@ -356,7 +355,7 @@ class ComponentVideo():
 
 
     def cleanup(self):
-        gl.glDeleteTextures(1, self.texture_id)
+        gl.glDeleteTextures(1, [self.texture_id])
         del self.shader
 
     @staticmethod

--- a/shadow/shadow.py
+++ b/shadow/shadow.py
@@ -125,8 +125,8 @@ class Shadow():
         gl.glDeleteVertexArrays(1, [self.vertex_array_id])
 
         log.debug('deleting framebuffer and texture')
-        gl.glDeleteFramebuffers(1, self.fbo)
-        gl.glDeleteTextures(1, self.texture)
+        gl.glDeleteFramebuffers(1, [self.fbo])
+        gl.glDeleteTextures(2, [self.texture, self.prevTexture])
 
         log.debug('closing glfw')
         glfw.terminate()
@@ -225,11 +225,10 @@ class ShadowWindow(Shadow):
             self.height = max(nheight, 10)
 
             # Delete existing framebuffer and create a new one with new scale
-            gl.glDeleteFramebuffers(1, self.fbo)
-            gl.glDeleteTextures(1, self.texture)
+            gl.glDeleteFramebuffers(1, [self.fbo])
+            gl.glDeleteTextures(2, [self.texture, self.prevTexture])
+            
             self.texture, self.fbo = create_framebuffer(self.width, self.height)
-
-            gl.glDeleteTextures(1, self.prevTexture)
             self.prevTexture = create_frametexture(self.width, self.height)
 
 class ShadowBackground(Shadow):
@@ -332,11 +331,10 @@ class ShadowWin10(Shadow):
             self.height = max(nheight, 10)
 
             # Delete existing framebuffer and create a new one with new scale
-            gl.glDeleteFramebuffers(1, self.fbo)
-            gl.glDeleteTextures(1, self.texture)
+            gl.glDeleteFramebuffers(1, [self.fbo])
+            gl.glDeleteTextures(2, [self.texture, self.prevTexture])
+            
             self.texture, self.fbo = create_framebuffer(self.width, self.height)
-
-            gl.glDeleteTextures(1, self.prevTexture)
             self.prevTexture = create_frametexture(self.width, self.height)
 
     def __del__(self):


### PR DESCRIPTION
I'm pretty sure I got them all (search for `glDelete`). If there are any other calls that take this array syntax (and have this same clumsy fragile wrapper interface) that'll probably have to be found separately.